### PR TITLE
Checking to see if modules folder exists

### DIFF
--- a/install_maya_module.bat
+++ b/install_maya_module.bat
@@ -2,6 +2,9 @@
 :: TOOL_NAME is determined by the current folder name
 for %%I in (.) do set TOOL_NAME=%%~nxI
 
+:: Check if modules folder exists
+if not exist %UserProfile%\Documents\maya\modules mkdir %UserProfile%\Documents\maya\modules
+
 :: Delete .mod file if it already exists
 del %UserProfile%\Documents\maya\modules\%TOOL_NAME%.mod
 


### PR DESCRIPTION
If the modules folder doesn't exist, the .bat file would still say it had copied the .mod to the modules folder, even though it didn't